### PR TITLE
Fix name in commander

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
 
 const program = require('commander');
 
+program._name = 'slate';
+
 require('./commands/build')(program);
 require('./commands/deploy')(program);
 require('./commands/start')(program);


### PR DESCRIPTION
@Shopify/themes-fed 

Was: `Usage: slate-tools [options] [command]`
Now: `Usage: slate [options] [command]`

Test by running a help command.
