### PR TITLE
Switch transpile to shopify/node

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "shopify"
+    "shopify/node"
   ],
   "plugins": [
     ["add-shopify-header", {


### PR DESCRIPTION
@Shopify/themes-fed 

This will transpile for node 4+ now. It'll keep `const` `=>` and other ES6 features that are supported by node.
