### PR TITLE
switch to cross platform spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "browser-sync": "2.13.0",
     "chokidar": "1.5.2",
     "commander": "2.9.0",
+    "cross-spawn": "^5.0.0",
     "debug": "2.2.0",
     "del": "2.2.0",
     "find-root": "1.0.0",

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,4 +1,4 @@
-const spawn = require('child_process').spawn;
+const spawn = require('cross-spawn');
 const debug = require('debug')('slate-tools:build');
 const config = require('./includes/config');
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,4 +1,4 @@
-const spawn = require('child_process').spawn;
+const spawn = require('cross-spawn');
 const debug = require('debug')('slate-tools:deploy');
 const config = require('./includes/config');
 

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -1,4 +1,4 @@
-const spawn = require('child_process').spawn;
+const spawn = require('cross-spawn');
 const debug = require('debug')('slate-tools:start');
 const config = require('./includes/config');
 

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,4 +1,4 @@
-const spawn = require('child_process').spawn;
+const spawn = require('cross-spawn');
 const debug = require('debug')('slate-tools:watch');
 const config = require('./includes/config');
 

--- a/src/commands/zip.js
+++ b/src/commands/zip.js
@@ -1,4 +1,4 @@
-const spawn = require('child_process').spawn;
+const spawn = require('cross-spawn');
 const debug = require('debug')('slate-tools:zip');
 const config = require('./includes/config');
 


### PR DESCRIPTION
use a cross platform spawn to allow slate-tools to work on windows

@Shopify/themes-fed 