### PR TITLE
Switch options from environment to env

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -15,7 +15,7 @@ export default function(program) {
       logger(`--gulpfile ${config.gulpFile}`);
       logger(`--cwd ${config.themeRoot}`);
 
-      const args = options.manual ? ['deploy:manual'] : ['deploy', '--environment', options.environment];
+      const args = options.manual ? ['deploy:manual'] : ['deploy', '--environment', options.env];
 
       spawn(config.gulp, args.concat(['--gulpfile', config.gulpFile, '--cwd', config.themeRoot]), {
         detached: false,

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -16,7 +16,7 @@ export default function(program) {
       logger(`--gulpfile ${config.gulpFile}`);
       logger(`--cwd ${config.themeRoot}`);
 
-      const args = ['--gulpfile', config.gulpFile, '--cwd', config.themeRoot, '--environment', options.environment];
+      const args = ['--gulpfile', config.gulpFile, '--cwd', config.themeRoot, '--environment', options.env];
 
       if (options.nosync) {
         args.push('--nosync');

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -16,7 +16,7 @@ export default function(program) {
       logger(`--gulpfile ${config.gulpFile}`);
       logger(`--cwd ${config.themeRoot}`);
 
-      const args = ['watch', '--gulpfile', config.gulpFile, '--cwd', config.themeRoot, '--environment', options.environment];
+      const args = ['watch', '--gulpfile', config.gulpFile, '--cwd', config.themeRoot, '--environment', options.env];
 
       if (options.nosync) {
         args.push('--nosync');


### PR DESCRIPTION
@Shopify/themes-fed @cshold 

Fix for https://github.com/Shopify/slate-tools/pull/24. Matching the update from `environment` to `env`. Options were not passing along.