### PR TITLE
Babel is deprecated in favour of babel-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "yargs": "6.4.0"
   },
   "devDependencies": {
-    "babel": "6.5.2",
     "babel-cli": "6.18.0",
     "babel-core": "6.18.2",
     "babel-plugin-add-shopify-header": "1.0.6",


### PR DESCRIPTION
@Shopify/themes-fed @cshold 

Removing `babel`... We don't use it. It's deprecated in favour of `babel-cli`.