### PR TITLE
validate theme_id on watch task

### DIFF
--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('zip', (done) => {
  * @static
  */
 gulp.task('watch', () => {
-  runSequence('build:config', defineWatchTasks());
+  runSequence('validate:id', 'build:config', defineWatchTasks());
 });
 
 function defineWatchTasks() {
@@ -77,7 +77,7 @@ function defineWatchTasks() {
  * @static
  */
 gulp.task('deploy', (done) => {
-  runSequence('build', 'deploy:replace', done);
+  runSequence('validate:id', 'build', 'deploy:replace', done);
 });
 
 /**

--- a/src/tasks/deploy-sync.js
+++ b/src/tasks/deploy-sync.js
@@ -31,7 +31,7 @@ gulp.task('deploy:sync-init', () => {
   let proxyTarget = `https://${envObj.store}`;
 
   // break theme preview cache by always setting a preview parameter
-  const previewParam = (envObj.theme_id === 'live') ? '' : envObj.theme_id;
+  const previewParam = (envObj.theme_id !== 'live') ? envObj.theme_id : '';
   proxyTarget += `?preview_theme_id=${previewParam}`;
 
   debug(proxyTarget);

--- a/src/tasks/deploy-sync.js
+++ b/src/tasks/deploy-sync.js
@@ -5,7 +5,6 @@ const yaml = require('js-yaml');
 const debug = require('debug')('slate-tools:deploy');
 
 const config = require('./includes/config.js');
-const utils = require('./includes/utilities.js');
 const messages = require('./includes/messages.js');
 
 /**
@@ -32,7 +31,7 @@ gulp.task('deploy:sync-init', () => {
   let proxyTarget = `https://${envObj.store}`;
 
   // break theme preview cache by always setting a preview parameter
-  let previewParam = (envObj.theme_id === "live") ? "" : envObj.theme_id;
+  const previewParam = (envObj.theme_id === 'live') ? '' : envObj.theme_id;
   proxyTarget += `?preview_theme_id=${previewParam}`;
 
   debug(proxyTarget);

--- a/src/tasks/deploy-sync.js
+++ b/src/tasks/deploy-sync.js
@@ -29,17 +29,11 @@ gulp.task('deploy:sync-init', () => {
   const environment = config.environment.split(/\s*,\s*|\s+/)[0];
 
   const envObj = tkConfig[environment];
-  const valid_id = utils.validateThemeId(envObj.theme_id);
   let proxyTarget = `https://${envObj.store}`;
 
-  if (!valid_id) {
-    messages.invalidThemeId(envObj.theme_id, environment);
-    process.exit();
-  }
-
-  if (valid_id && typeof(valid_id) === "number") {
-    proxyTarget += `?preview_theme_id=${valid_id}`;
-  }
+  // break theme preview cache by always setting a preview parameter
+  let previewParam = (envObj.theme_id === "live") ? "" : envObj.theme_id;
+  proxyTarget += `?preview_theme_id=${previewParam}`;
 
   debug(proxyTarget);
 

--- a/src/tasks/deploy-sync.js
+++ b/src/tasks/deploy-sync.js
@@ -5,6 +5,7 @@ const yaml = require('js-yaml');
 const debug = require('debug')('slate-tools:deploy');
 
 const config = require('./includes/config.js');
+const utils = require('./includes/utilities.js');
 const messages = require('./includes/messages.js');
 
 /**
@@ -28,10 +29,16 @@ gulp.task('deploy:sync-init', () => {
   const environment = config.environment.split(/\s*,\s*|\s+/)[0];
 
   const envObj = tkConfig[environment];
+  const valid_id = utils.validateThemeId(envObj.theme_id);
   let proxyTarget = `https://${envObj.store}`;
 
-  if (envObj.theme_id && (envObj.theme_id === parseInt(envObj.theme_id, 10))) {
-    proxyTarget += `?preview_theme_id=${envObj.theme_id}`;
+  if (!valid_id) {
+    messages.invalidThemeId(envObj.theme_id, environment);
+    process.exit();
+  }
+
+  if (valid_id && typeof(valid_id) === "number") {
+    proxyTarget += `?preview_theme_id=${valid_id}`;
   }
 
   debug(proxyTarget);

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -38,6 +38,67 @@ function deploy(env) {
 }
 
 /**
+ * Validate theme_id used for the environment
+ * @param {Object} - settings of theme_id and environment
+ * @returns {Promise}
+ * @private
+ */
+function validateId(settings) {
+  return new Promise((resolve, reject) => {
+    // Only string allowed is "live"
+    if (settings.themeId === 'live') {
+      resolve();
+    }
+
+    const id = Number(settings.themeId);
+
+    if(isNaN(id)) {
+      reject(settings);
+    } else {
+      resolve();
+    }
+  });
+}
+
+/**
+ * Validate the config.yml theme_id is an integer or "live"
+ * @function validate:id
+ *
+ */
+
+ gulp.task('validate:id', () => {
+   const file = fs.readFileSync(config.tkConfig, 'utf8');
+   const tkConfig = yaml.safeLoad(file);
+   let envObj;
+
+   const environments = config.environment.split(/\s*,\s*|\s+/);
+   const promises = [];
+
+   environments.forEach((environment) => {
+     function factory() {
+       envObj = tkConfig[environment];
+       let envSettings = {
+         'themeId' : envObj.theme_id,
+         environment
+       }
+
+       return validateId(envSettings);
+     }
+     promises.push(factory);
+   });
+
+  return utils.promiseSeries(promises)
+    .then()
+    .catch((result) => {
+      // stop process to prevent deploy defaulting to published theme
+      messages.invalidThemeId(result.themeId, result.environment);
+      const exitCode = 2;
+      return process.exit(exitCode);
+    });
+
+ });
+
+/**
  * Replace your existing theme using ThemeKit.
  *
  * @function deploy:replace

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -52,7 +52,7 @@ function validateId(settings) {
 
     const id = Number(settings.themeId);
 
-    if(isNaN(id)) {
+    if (isNaN(id)) {
       reject(settings);
     } else {
       resolve();
@@ -66,26 +66,26 @@ function validateId(settings) {
  *
  */
 
- gulp.task('validate:id', () => {
-   const file = fs.readFileSync(config.tkConfig, 'utf8');
-   const tkConfig = yaml.safeLoad(file);
-   let envObj;
+gulp.task('validate:id', () => {
+  const file = fs.readFileSync(config.tkConfig, 'utf8');
+  const tkConfig = yaml.safeLoad(file);
+  let envObj;
 
-   const environments = config.environment.split(/\s*,\s*|\s+/);
-   const promises = [];
+  const environments = config.environment.split(/\s*,\s*|\s+/);
+  const promises = [];
 
-   environments.forEach((environment) => {
-     function factory() {
-       envObj = tkConfig[environment];
-       let envSettings = {
-         'themeId' : envObj.theme_id,
-         environment
-       }
+  environments.forEach((environment) => {
+    function factory() {
+      envObj = tkConfig[environment];
+      const envSettings = {
+        themeId: envObj.theme_id,
+        environment,
+      };
 
-       return validateId(envSettings);
-     }
-     promises.push(factory);
-   });
+      return validateId(envSettings);
+    }
+    promises.push(factory);
+  });
 
   return utils.promiseSeries(promises)
     .then()
@@ -96,7 +96,7 @@ function validateId(settings) {
       return process.exit(exitCode);
     });
 
- });
+});
 
 /**
  * Replace your existing theme using ThemeKit.

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -89,7 +89,6 @@ gulp.task('validate:id', () => {
   });
 
   return utils.promiseSeries(promises)
-    .then()
     .catch((result) => {
       // stop process to prevent deploy defaulting to published theme
       messages.invalidThemeId(result.themeId, result.environment);

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -63,7 +63,8 @@ function validateId(settings) {
 /**
  * Validate the config.yml theme_id is an integer or "live"
  * @function validate:id
- *
+ * @memberof slate-cli.tasks.watch, slate-cli.tasks.deploy
+ * @private
  */
 
 gulp.task('validate:id', () => {

--- a/src/tasks/includes/messages.js
+++ b/src/tasks/includes/messages.js
@@ -74,9 +74,9 @@ const messages = {
   },
 
   invalidThemeId: (themeId, env) => {
-    gutil.log(`Invalid theme id for`,
+    gutil.log('Invalid theme id for',
       gutil.colors.cyan(`${env}: ${themeId}`),
-      gutil.colors.yellow(`\`theme_id\` must be an integer or "live".`)
+      gutil.colors.yellow('`theme_id` must be an integer or "live".'),
     );
   },
 

--- a/src/tasks/includes/messages.js
+++ b/src/tasks/includes/messages.js
@@ -73,6 +73,13 @@ const messages = {
       ' and run a full <slate deploy> as a result.';
   },
 
+  invalidThemeId: (theme_id, env) => {
+    gutil.log(`Invalid ID: `,
+      gutil.colors.cyan(`${env}: ${theme_id} `),
+      gutil.colors.yellow(`\`theme_id\` must be an integer or "live".`)
+    );
+  },
+
   configError: () => {
     return '`config.yml` does not exist. You need to add a config file before you can upload your theme to Shopify.';
   },

--- a/src/tasks/includes/messages.js
+++ b/src/tasks/includes/messages.js
@@ -73,9 +73,9 @@ const messages = {
       ' and run a full <slate deploy> as a result.';
   },
 
-  invalidThemeId: (theme_id, env) => {
-    gutil.log(`Invalid ID: `,
-      gutil.colors.cyan(`${env}: ${theme_id} `),
+  invalidThemeId: (themeId, env) => {
+    gutil.log(`Invalid theme id for`,
+      gutil.colors.cyan(`${env}: ${themeId}`),
       gutil.colors.yellow(`\`theme_id\` must be an integer or "live".`)
     );
   },

--- a/src/tasks/includes/utilities.js
+++ b/src/tasks/includes/utilities.js
@@ -39,6 +39,24 @@ const utilities = {
     }).thenReturn(results).all();
   },
 
+  validateThemeId: (themeId) => {
+    // Only string allowed is "live"
+    if (themeId === "live") {
+      return true;
+    }
+
+    try {
+      const id = Number(themeId);
+      if(isNaN(id)) {
+        throw false;
+      } else {
+        return id;
+      }
+    }
+    catch(err) {
+      return err;
+    }
+  },
   /**
    * Checks whether the path is a directory
    *

--- a/src/tasks/includes/utilities.js
+++ b/src/tasks/includes/utilities.js
@@ -39,24 +39,6 @@ const utilities = {
     }).thenReturn(results).all();
   },
 
-  validateThemeId: (themeId) => {
-    // Only string allowed is "live"
-    if (themeId === "live") {
-      return true;
-    }
-
-    try {
-      const id = Number(themeId);
-      if(isNaN(id)) {
-        throw false;
-      } else {
-        return id;
-      }
-    }
-    catch(err) {
-      return err;
-    }
-  },
   /**
    * Checks whether the path is a directory
    *


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate-cli/issues/115

Scoped to the `slate watch` task as this is prepending the value of `envObj.theme_id` to the preview URL.

Allows `theme_id` to be one of three things:
* The string `"live"`.
* An integer, e.g. `123456789`
* Or a string that becomes an integer with `Number()`,  e.g. `"123456789"`

If the `theme_id` is found not to be valid, an error message is shown.

![](http://take.ms/J2tLx)

#### To do still:
* Need to check references in docs about permitted values for `theme_id`.  For example, make sure it doesn't say you can leave it blank.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

