### PR TITLE
Add slate test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
+    "@shopify/theme-lint": "^1.0.2",
     "@shopify/themekit": "0.6.6",
     "bluebird": "3.4.6",
     "browser-sync": "2.18.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
-    "@shopify/theme-lint": "1.0.2",
+    "@shopify/theme-lint": "1.0.3",
     "@shopify/themekit": "0.6.6",
     "bluebird": "3.4.6",
     "browser-sync": "2.18.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
-    "@shopify/theme-lint": "^1.0.2",
+    "@shopify/theme-lint": "1.0.2",
     "@shopify/themekit": "0.6.6",
     "bluebird": "3.4.6",
     "browser-sync": "2.18.2",

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,0 +1,20 @@
+import spawn from 'cross-spawn';
+import debug from 'debug';
+import config from '../config';
+
+const logger = debug('slate-tools:test');
+
+export default function(program) {
+  program
+    .command('test')
+    .description('Runs translation tests for a theme\'s locale files (<theme>/src/locales/).')
+    .action(() => {
+      logger(`--gulpfile ${config.gulpFile}`);
+      logger(`--cwd ${config.themeRoot}`);
+
+      spawn(config.gulp, ['test', '--gulpfile', config.gulpFile, '--cwd', config.themeRoot], {
+        detached: false,
+        stdio: 'inherit',
+      });
+    });
+}

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -29,15 +29,14 @@ gulp.task('build:zip', (done) => {
 });
 
 /**
- * Does a rebuild of your theme's locale files and runs translation
- * tests on each file using @shopify/theme-lint
+ * Runs translation tests on each file using @shopify/theme-lint
  *
  * @function test
  * @memberof slate-cli.tasks
  * @static
  */
 gulp.task('test', (done) => {
-  runSequence('build:locales', 'lint:locales', done);
+  runSequence('lint:locales', done);
 });
 
 /**

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -29,6 +29,18 @@ gulp.task('build:zip', (done) => {
 });
 
 /**
+ * Does a rebuild of your theme's locale files and runs translation
+ * tests on each file using @shopify/theme-lint
+ *
+ * @function test
+ * @memberof slate-cli.tasks
+ * @static
+ */
+gulp.task('test', (done) => {
+  runSequence('build:locales', 'lint:locales', done);
+});
+
+/**
  * Does a full clean/rebuild of your theme and creates a `.zip` compatible with
  * shopify.
  *

--- a/src/tasks/includes/lint-reporter.js
+++ b/src/tasks/includes/lint-reporter.js
@@ -1,0 +1,52 @@
+const gutil = require('gulp-util');
+
+/** Class representing a custom reporter for @shopify/theme-lint */
+export default class Reporter {
+  constructor() {
+    this.successes = [];
+    this.failures = [];
+  }
+
+  /**
+   * Pushes a valid message onto successes.
+   *
+   * @param {String} message
+   * @param {String} file
+   */
+  success(message, file = null) {
+    this.successes.push([message, file]);
+  }
+
+  /**
+   * Pushes an invalid message onto failures.
+   *
+   * @param {String} message
+   * @param {String} file
+   */
+  failure(message, file) {
+    this.failures.push([message, file]);
+  }
+
+  /**
+   * Finalizes string output for translation tests
+   * depending on successes and failures.
+   */
+  finalize() {
+    const testsRun = this.failures.length + this.successes.length;
+
+    if (this.failures.length === 0) {
+      gutil.log('Translation tests complete:',
+        gutil.colors.green(`Success (${testsRun} checks run)`),
+      );
+    } else {
+      gutil.log('Translation tests complete:',
+        gutil.colors.red(`Failed (${testsRun} checks run)`),
+      );
+
+      this.failures.forEach(([message, file]) => {
+        gutil.log(gutil.colors.red(`${file}:`));
+        gutil.log(message.replace(/\n/g, ' '));
+      });
+    }
+  }
+}

--- a/src/tasks/includes/lint-reporter.js
+++ b/src/tasks/includes/lint-reporter.js
@@ -23,7 +23,7 @@ export default class Reporter {
    * @param {String} message
    * @param {String} file
    */
-  failure(message, file) {
+  failure(message, file = null) {
     this.failures.push([message, file]);
   }
 

--- a/src/tasks/includes/lint-reporter.js
+++ b/src/tasks/includes/lint-reporter.js
@@ -1,4 +1,5 @@
 const gutil = require('gulp-util');
+const _ = require('lodash');
 
 /** Class representing a custom reporter for @shopify/theme-lint */
 export default class Reporter {
@@ -28,10 +29,10 @@ export default class Reporter {
   }
 
   /**
-   * Finalizes string output for translation tests
+   * Builds string output for translation tests
    * depending on successes and failures.
    */
-  finalize() {
+  output() {
     const testsRun = this.failures.length + this.successes.length;
 
     if (this.failures.length === 0) {
@@ -43,10 +44,17 @@ export default class Reporter {
         gutil.colors.red(`Failed (${testsRun} checks run)`),
       );
 
-      this.failures.forEach(([message, file]) => {
+      const failureGroups = _.groupBy(this.failures, (failure) => failure[1]);
+
+      _.forOwn(failureGroups, (failures, file) => {
         gutil.log(gutil.colors.red(`${file}:`));
-        gutil.log(message);
+
+        failures.map((failure) => {
+          return gutil.log(failure[0]);
+        });
       });
     }
+
+    this.successes = this.failures = [];
   }
 }

--- a/src/tasks/includes/lint-reporter.js
+++ b/src/tasks/includes/lint-reporter.js
@@ -13,8 +13,8 @@ export default class Reporter {
    * @param {String} message
    * @param {String} file
    */
-  success(message, file = null) {
-    this.successes.push([message, file]);
+  success(message, file = null, index = null) {
+    this.successes.push([message, file, index]);
   }
 
   /**
@@ -23,8 +23,8 @@ export default class Reporter {
    * @param {String} message
    * @param {String} file
    */
-  failure(message, file = null) {
-    this.failures.push([message, file]);
+  failure(message, file = null, index = null) {
+    this.failures.push([message, file, index]);
   }
 
   /**
@@ -45,7 +45,7 @@ export default class Reporter {
 
       this.failures.forEach(([message, file]) => {
         gutil.log(gutil.colors.red(`${file}:`));
-        gutil.log(message.replace(/\n/g, ' '));
+        gutil.log(message);
       });
     }
   }

--- a/src/tasks/lint-locales.js
+++ b/src/tasks/lint-locales.js
@@ -1,0 +1,74 @@
+const gulp = require('gulp');
+const plumber = require('gulp-plumber');
+const size = require('gulp-size');
+const _ = require('lodash');
+const registeredLinters = require('@shopify/theme-lint').linters;
+
+const config = require('./includes/config.js');
+const utils = require('./includes/utilities.js');
+const messages = require('./includes/messages.js');
+const Reporter = require('./includes/lint-reporter.js').default;
+
+/**
+ * Copies locales to the `/dist/locales` directory
+ *
+ * @param {String} directory
+ * @returns {Stream}
+ * @private
+ */
+function processLocales(directory) {
+  messages.logProcessFiles('build:locales');
+
+  return gulp.src(directory, {base: config.src.root})
+    .pipe(plumber(utils.errorHandler))
+    .pipe(size({
+      showFiles: true,
+      pretty: true,
+    }))
+    .pipe(gulp.dest(config.dist.root));
+}
+
+/**
+ * Recursively loops over all translations and keeps track of successes
+ * and failures. The reporter then outputs the results once completed.
+ *
+ * @param {String} directory
+ * @param {Array} linters
+ * @returns {Function|String} Recursive function call or finalized output
+ * @private
+ */
+function lintLocales(directory, linters, reporter = new Reporter()) {
+  const Linter = linters[0];
+
+  if (Linter) {
+    const linter = new Linter(directory);
+
+    return linter.run(reporter).then(() => {
+      return lintLocales(directory, linters.slice(1), reporter);
+    });
+  } else {
+    return reporter.finalize();
+  }
+}
+
+/**
+ * Copies locales to the `/dist/locales` directory
+ *
+ * @function build:locales
+ * @memberof slate-cli.tasks.build
+ * @static
+ */
+gulp.task('build:locales', () => {
+  return processLocales(config.src.locales);
+});
+
+/**
+ * Runs translation tests using @shopify/theme-lint
+ *
+ * @function lint:locales
+ * @memberof slate-cli.tasks.lint
+ * @static
+ */
+gulp.task('lint:locales', () => {
+  return lintLocales(config.dist.root, _.values(registeredLinters));
+});

--- a/src/tasks/lint-locales.js
+++ b/src/tasks/lint-locales.js
@@ -1,33 +1,23 @@
 const gulp = require('gulp');
-const _ = require('lodash');
-const chokidar = require('chokidar');
-const registeredLinters = require('@shopify/theme-lint').linters;
+const {runAll} = require('@shopify/theme-lint');
 
 const config = require('./includes/config.js');
-const messages = require('./includes/messages.js');
 const Reporter = require('./includes/lint-reporter.js').default;
 
 /**
- * Recursively loops over all translations and keeps track of successes
- * and failures. The reporter then outputs the results once completed.
+ * Runs all the translation tests and the reporter outputs
+ * the locale results once completed.
  *
- * @param {String} directory
- * @param {Array} linters
- * @returns {Function|String} Recursive function call or finalized output
+ * @returns {String} Finalized linting output
  * @private
  */
-function lintLocales(directory, linters, reporter = new Reporter()) {
-  const Linter = linters[0];
-
-  if (Linter) {
-    const linter = new Linter(directory);
-
-    return linter.run(reporter).then(() => {
-      return lintLocales(directory, linters.slice(1), reporter);
-    });
-  } else {
+function lintLocales() {
+  return runAll(config.src.root, new Reporter()).then((reporter) => {
     return reporter.finalize();
-  }
+  }).catch((err) => {
+    console.log(err);
+    process.on('exit', () => process.exit(1));
+  });
 }
 
 /**
@@ -38,21 +28,5 @@ function lintLocales(directory, linters, reporter = new Reporter()) {
  * @static
  */
 gulp.task('lint:locales', () => {
-  return lintLocales(config.src.root, _.values(registeredLinters));
+  return lintLocales();
 });
-
-/**
- * Watches locales in the `/src` directory
- *
- * @function watch:locales
- * @memberof slate-cli.tasks.watch
- * @static
- */
-gulp.task('watch:locales', () => {
-  chokidar.watch(config.src.locales, {ignoreInitial: true})
-    .on('all', (event, path) => {
-      messages.logFileEvent(event, path);
-      lintLocales(config.src.root, _.values(registeredLinters));
-    });
-});
-

--- a/src/tasks/lint-locales.js
+++ b/src/tasks/lint-locales.js
@@ -14,9 +14,6 @@ const Reporter = require('./includes/lint-reporter.js').default;
 function lintLocales() {
   return runAll(config.src.root, new Reporter()).then((reporter) => {
     return reporter.finalize();
-  }).catch((err) => {
-    console.log(err);
-    process.on('exit', () => process.exit(1));
   });
 }
 

--- a/src/tasks/lint-locales.js
+++ b/src/tasks/lint-locales.js
@@ -13,7 +13,7 @@ const Reporter = require('./includes/lint-reporter.js').default;
  */
 function lintLocales() {
   return runAll(config.src.root, new Reporter()).then((reporter) => {
-    return reporter.finalize();
+    return reporter.output();
   });
 }
 

--- a/src/tasks/watchers.js
+++ b/src/tasks/watchers.js
@@ -85,6 +85,7 @@ function deploy(cmd, files, env) {
  */
 gulp.task('watch:src', [
   'watch:assets',
+  'watch:locales',
   'watch:config',
   'watch:svg',
   'watch:css',

--- a/src/tasks/watchers.js
+++ b/src/tasks/watchers.js
@@ -85,7 +85,6 @@ function deploy(cmd, files, env) {
  */
 gulp.task('watch:src', [
   'watch:assets',
-  'watch:locales',
   'watch:config',
   'watch:svg',
   'watch:css',


### PR DESCRIPTION
Fixes #5.

Adds a new slate test command that tests for translation validity using [@shopify/theme-lint](https://www.npmjs.com/package/@shopify/theme-lint).

### Checklist
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

