### PR TITLE
Add Circle CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # @shopify/slate-tools
+[![CircleCI](https://circleci.com/gh/Shopify/slate-tools.svg?style=svg&circle-token=0b8147527ef88134b4238064a563ceaaae98f06a)](https://circleci.com/gh/Shopify/slate-tools)
 
 Tooling for Shopify themes using [Slate](https://github.com/Shopify/slate).
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  node:
+    version: 6.2.2
+
+dependencies:
+  post:
+    - npm run prepublish
+    - npm link
+
+test:
+  override:
+    - npm run lint

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "start": "npm run clean && babel -w -d lib/ src/",
     "test": "npm run lint",
     "prepublish": "npm test && npm run clean && babel -d lib/ src/",
-    "lint": "eslint --max-warnings 0 -c .eslintrc.json src/ test/",
-    "lint-allow-warning": "eslint -c .eslintrc.json src/ test/"
+    "lint": "eslint --max-warnings 0 -c .eslintrc.json src/",
+    "lint-allow-warning": "eslint -c .eslintrc.json src/"
   },
   "keywords": [
     "shopify",


### PR DESCRIPTION
Fixes #53.

Adds Circle CI tests to the `slate-tools` GitHub repository.