### PR TITLE
Remove error thrown when running slate build

### DIFF
--- a/src/tasks/build-config.js
+++ b/src/tasks/build-config.js
@@ -11,11 +11,6 @@ const messages = require('./includes/messages.js');
 function processConfig(file) {
   messages.logProcessFiles('build:config');
 
-  // eslint-disable-next-line no-sync, node/no-deprecated-api
-  if (!fs.existsSync(file)) {
-    throw new Error(messages.configError());
-  }
-
   return gulp.src(file)
     .pipe(plumber(utils.errorHandler))
     .pipe(size({

--- a/src/tasks/build-config.js
+++ b/src/tasks/build-config.js
@@ -1,5 +1,4 @@
 const gulp = require('gulp');
-const fs = require('fs');
 const plumber = require('gulp-plumber');
 const size = require('gulp-size');
 const chokidar = require('chokidar');

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -72,10 +72,14 @@ gulp.task('validate:id', () => {
   try {
     file = fs.readFileSync(config.tkConfig, 'utf8');
   } catch (err) {
-    messages.configError();
+    if (err.code === 'ENOENT') {
+      messages.configError();
 
-    const exitCode = 2;
-    return process.exit(exitCode);
+      const exitCode = 2;
+      return process.exit(exitCode);
+    }
+
+    throw new Error(err);
   }
 
   const tkConfig = yaml.safeLoad(file);

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -72,14 +72,14 @@ gulp.task('validate:id', () => {
   try {
     file = fs.readFileSync(config.tkConfig, 'utf8');
   } catch (err) {
-    if (err.code === 'ENOENT') {
-      messages.configError();
-
-      const exitCode = 2;
-      return process.exit(exitCode);
+    if (err.code !== 'ENOENT') {
+      throw new Error(err);
     }
 
-    throw new Error(err);
+    messages.configError();
+
+    const exitCode = 2;
+    return process.exit(exitCode);
   }
 
   const tkConfig = yaml.safeLoad(file);

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -66,7 +66,6 @@ function validateId(settings) {
  * @memberof slate-cli.tasks.watch, slate-cli.tasks.deploy
  * @private
  */
-
 gulp.task('validate:id', () => {
   let file;
 
@@ -105,7 +104,6 @@ gulp.task('validate:id', () => {
       const exitCode = 2;
       return process.exit(exitCode);
     });
-
 });
 
 /**

--- a/src/tasks/deploy-utils.js
+++ b/src/tasks/deploy-utils.js
@@ -68,7 +68,17 @@ function validateId(settings) {
  */
 
 gulp.task('validate:id', () => {
-  const file = fs.readFileSync(config.tkConfig, 'utf8');
+  let file;
+
+  try {
+    file = fs.readFileSync(config.tkConfig, 'utf8');
+  } catch (err) {
+    messages.configError();
+
+    const exitCode = 2;
+    return process.exit(exitCode);
+  }
+
   const tkConfig = yaml.safeLoad(file);
   let envObj;
 

--- a/src/tasks/includes/messages.js
+++ b/src/tasks/includes/messages.js
@@ -82,7 +82,7 @@ const messages = {
 
   configError: () => {
     gutil.log('File missing:',
-      gutil.colors.yellow('`config.yml` does not exist. You need to add a config file before you can upload your theme to Shopify.'),
+      gutil.colors.yellow('`config.yml` does not exist. You need to add a config file before you can make changes to your Shopify store.'),
     );
   },
 

--- a/src/tasks/includes/messages.js
+++ b/src/tasks/includes/messages.js
@@ -81,7 +81,9 @@ const messages = {
   },
 
   configError: () => {
-    return '`config.yml` does not exist. You need to add a config file before you can upload your theme to Shopify.';
+    gutil.log('File missing:',
+      gutil.colors.yellow('`config.yml` does not exist. You need to add a config file before you can upload your theme to Shopify.'),
+    );
   },
 
   deployTo: (environment) => {


### PR DESCRIPTION
Fixes #45 and fixes Shopify/slate-cli#118.

Not sure if this is the best approach but wanted your thoughts. This removes the `throw new Error()` output when there isn't a `config.yml` in the theme root folder and when `slate build` is ran.

I brought the error logic to the `invalidate:id` task, which is called for `slate watch` and `slate deploy`. This ensures the config has been created, otherwise the process will exit before it "links" the local theme folder to the store.

Output when running either sync command:

![image](https://cloud.githubusercontent.com/assets/991693/25823206/55eedaec-3409-11e7-8d7a-0170165dcd4a.png)

The `slate build` command will build without any errors now.

@cshold 