### PR TITLE
Add error output at end of build and zip tasks

### DIFF
--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -4,6 +4,8 @@ const debug = require('debug')('slate-tools');
 const argv = require('yargs').argv;
 const runSequence = require('run-sequence');
 
+const utils = require('./tasks/includes/utilities.js');
+
 if (argv.environment && argv.environment !== 'undefined') {
   debug(`setting tkEnvironments to ${argv.environment}`);
   gutil.env.environments = argv.environment;
@@ -16,6 +18,7 @@ gulp.task('build', (done) => {
   runSequence(
     ['clean'],
     ['build:js', 'build:vendor-js', 'build:css', 'build:assets', 'build:config', 'build:svg'],
+    ['output:errors'],
     done,
   );
 });
@@ -48,7 +51,7 @@ gulp.task('test', (done) => {
  * @static
  */
 gulp.task('zip', (done) => {
-  runSequence('build:zip', 'compress', done);
+  runSequence('build:zip', 'compress', 'output:errors', done);
 });
 
 /**
@@ -114,4 +117,12 @@ gulp.task('deploy:manual', (done) => {
  */
 gulp.task('default', (done) => {
   runSequence('deploy', 'watch', done);
+});
+
+/**
+ * Handles the error summary at the end if there are errors to output.
+ * This task will only be run for the build and zip tasks.
+ */
+gulp.task('output:errors', () => {
+  utils.outputErrors();
 });

--- a/src/tasks/includes/utilities.js
+++ b/src/tasks/includes/utilities.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const _ = require('lodash');
 const Promise = require('bluebird');
 
+let errors = [];
+
 /**
  * Utility and reusable functions used by our Gulp Tasks
  *
@@ -13,13 +15,36 @@ const Promise = require('bluebird');
 const utilities = {
 
   /**
-   * Generic error handler for streams called in `watch` tasks (used by gulp-plumber)
+   * Handles the output for any errors that might have been captured
+   * during the build and zip Gulp tasks.
+   *
+   * @memberof slate-cli.utilities
+   */
+  outputErrors: () => {
+    if (!errors.length) {
+      return;
+    }
+
+    gutil.log(gutil.colors.red(`There were errors during the build:\n`));
+
+    errors.forEach((err) => {
+      gutil.log(gutil.colors.red(err));
+    });
+
+    errors = [];
+  },
+
+  /**
+   * Generic error handler for streams called in `watch` tasks (used by gulp-plumber).
+   * Any error that is thrown inside of a task is added to the errors array.
    *
    * @memberof slate-cli.utilities
    * @param {Error} err
    */
-  errorHandler: function(err) { // eslint-disable-line babel/object-shorthand
+  errorHandler: (err) => {
     gutil.log(gutil.colors.red(err));
+    errors.push(err);
+
     this.emit('end');
   },
 


### PR DESCRIPTION
Fixes #58.

Adds error output at the end of the `build` and `zip` Gulp tasks before the `done` callback.

Basic concept is it keeps track of any errors that are passed through `gulp-plumber`. An `output:errors` task is then fired. Side note: the `this.emit` event was kind of a mystery - didn't seem to be used for anything so removed it.

cc @t-kelly 