### PR TITLE
Upgrade require-dir to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "js-yaml": "3.7.0",
     "lodash": "4.17.2",
     "open": "0.0.5",
-    "require-dir": "0.3.1",
+    "require-dir": "0.3.2",
     "run-sequence": "1.2.2",
     "vinyl-paths": "2.1.0",
     "yargs": "6.4.0"


### PR DESCRIPTION
Fixes slate CLI command failures on Node v8.

### What are you trying to accomplish with this PR?

Fixes [issue #170 in slate](https://github.com/Shopify/slate/issues/170). See [issue #45 in requireDir](https://github.com/aseemk/requireDir/issues/45) for details of the fix introduced in 0.3.2.


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.