### PR TITLE
Upgrade browser-sync to 2.18.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@shopify/theme-lint": "1.0.3",
     "@shopify/themekit": "0.6.6",
     "bluebird": "3.4.6",
-    "browser-sync": "2.18.2",
+    "browser-sync": "2.18.12",
     "chokidar": "1.6.1",
     "cross-spawn": "5.0.1",
     "debug": "2.3.3",


### PR DESCRIPTION
Fixes 'Disconnected from BrowserSync' message in the browser.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

