### PR TITLE
Fix slate test command passing on Circle CI

### DIFF
--- a/src/tasks/includes/lint-reporter.js
+++ b/src/tasks/includes/lint-reporter.js
@@ -1,6 +1,8 @@
 const gutil = require('gulp-util');
 const _ = require('lodash');
 
+const messages = require('./messages.js');
+
 /** Class representing a custom reporter for @shopify/theme-lint */
 export default class Reporter {
   constructor() {
@@ -53,6 +55,8 @@ export default class Reporter {
           return gutil.log(failure[0]);
         });
       });
+
+      throw new Error(messages.translationsFailed());
     }
 
     this.successes = this.failures = [];

--- a/src/tasks/includes/messages.js
+++ b/src/tasks/includes/messages.js
@@ -73,6 +73,10 @@ const messages = {
       ' and run a full <slate deploy> as a result.';
   },
 
+  translationsFailed: () => {
+    return 'Translation errors detected.';
+  },
+
   invalidThemeId: (themeId, env) => {
     gutil.log('Invalid theme id for',
       gutil.colors.cyan(`${env}: ${themeId}`),


### PR DESCRIPTION
Fixes #71.

Instead of simply looping over the translation failures and outputting them, we can throw an error to halt Circle CI execution and avoid all tests from passing even though there's errors.