### PR TITLE
Add script that hides persists preview bar minimize

### DIFF
--- a/src/tasks/deploy-sync.js
+++ b/src/tasks/deploy-sync.js
@@ -24,7 +24,6 @@ gulp.task('deploy:sync-init', () => {
   }
 
   const file = fs.readFileSync(config.tkConfig, 'utf8'); // eslint-disable-line no-sync
-  console.log(__dirname);
   const devScript = fs.readFileSync(path.join(__dirname, '/includes/dev-script.js'));
   const tkConfig = yaml.safeLoad(file);
   const queryStringComponents = [];
@@ -59,7 +58,9 @@ gulp.task('deploy:sync-init', () => {
       rule: {
         match: /<\/body>/i,
         fn: (snippet, match) => {
-          return `<script defer="defer">${devScript}</script>${snippet}${match}`;
+          return `<script defer="defer">${devScript}</script>
+                  ${snippet}
+                  ${match}`;
         },
       },
     },

--- a/src/tasks/deploy-sync.js
+++ b/src/tasks/deploy-sync.js
@@ -1,4 +1,5 @@
 const gulp = require('gulp');
+const path = require('path');
 const browserSync = require('browser-sync').create();
 const fs = require('fs');
 const yaml = require('js-yaml');
@@ -23,6 +24,8 @@ gulp.task('deploy:sync-init', () => {
   }
 
   const file = fs.readFileSync(config.tkConfig, 'utf8'); // eslint-disable-line no-sync
+  console.log(__dirname);
+  const devScript = fs.readFileSync(path.join(__dirname, '/includes/dev-script.js'));
   const tkConfig = yaml.safeLoad(file);
   const queryStringComponents = [];
   const environment = config.environment.split(/\s*,\s*|\s+/)[0];
@@ -49,6 +52,15 @@ gulp.task('deploy:sync-init', () => {
         const prefix = req.url.indexOf('?') > -1 ? '&' : '?';
         req.url += prefix + queryStringComponents.join('&');
         next();
+      },
+    },
+    snippetOptions: {
+      // Provide a custom Regex for inserting the snippet.
+      rule: {
+        match: /<\/body>/i,
+        fn: (snippet, match) => {
+          return `<script defer="defer">${devScript}</script>${snippet}${match}`;
+        },
       },
     },
   });

--- a/src/tasks/includes/dev-script.js
+++ b/src/tasks/includes/dev-script.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 /*******************************************************************************
- * Development Script
+ * Development script
  *
  * This script is only included on the page when Browsersync is being used. It's
  * a great place to put any customizations that you only want to occur while
@@ -10,7 +10,7 @@
 
 
 /**
- * Persistent Preview Bar Minimize
+ * Persistent preview bar minimization
  *
  * Adds a token to sessionStorage when the 'minimize' button is clicked on the
  * preview bar that appears when previewing an unpublished theme. This token is
@@ -18,50 +18,50 @@
  */
 
 (function() {
-  if (!isLocalStorageSupported) { return; }
+  if (!isSessionStorageSupported()) { return; }
 
   window.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('click', onButtonClick);
 
-    if (window.sessionStorage.getItem('hide-preview')) {
+    if (window.sessionStorage.getItem('preview-bar-hidden')) {
       hidePreviewBar();
     }
-  })
+  });
 
   function onButtonClick(event) {
     var element = event.target;
 
     if (element.className.indexOf('shopify-preview-bar__minimize') === -1) { return; }
 
-    window.sessionStorage.setItem('hide-preview', 'true');
+    window.sessionStorage.setItem('preview-bar-hidden', 'true');
     hidePreviewBar();
     document.removeEventListener('click', onButtonClick);
   }
 
   function hidePreviewBar() {
-    addCSS('.shopify-preview-bar { display:none; }');
+    injectStyles('.shopify-preview-bar { display:none; }');
   }
 
-  function addCSS(css){
+  function injectStyles(css) {
     var head = document.getElementsByTagName('head')[0];
     var style = document.createElement('style');
 
     style.setAttribute('type', 'text/css');
 
-    if (style.styleSheet) {   // IE
+    if (style.styleSheet) { // IE
       style.styleSheet.cssText = css;
-    } else {                // Everything else
+    } else { // Everything else
       style.appendChild(document.createTextNode(css));
     }
 
     head.appendChild(style);
   }
 
-  function isLocalStorageSupported () {
-    var mod = 'modernizr';
+  function isSessionStorageSupported() {
+    var mod = 'slate';
     try {
-      localStorage.setItem(mod, mod);
-      localStorage.removeItem(mod);
+      sessionStorage.setItem(mod, mod);
+      sessionStorage.removeItem(mod);
       return true;
     } catch (e) {
       return false;

--- a/src/tasks/includes/dev-script.js
+++ b/src/tasks/includes/dev-script.js
@@ -1,0 +1,71 @@
+/* eslint-disable */
+
+/*******************************************************************************
+ * Development Script
+ *
+ * This script is only included on the page when Browsersync is being used. It's
+ * a great place to put any customizations that you only want to occur while
+ * developing your theme.
+ ******************************************************************************/
+
+
+/**
+ * Persistent Preview Bar Minimize
+ *
+ * Adds a token to sessionStorage when the 'minimize' button is clicked on the
+ * preview bar that appears when previewing an unpublished theme. This token is
+ * checked for on subsequent page loads, and if found, the preview is hidden.
+ */
+
+(function() {
+  if (!isLocalStorageSupported) { return; }
+
+  window.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('click', onButtonClick);
+
+    if (window.sessionStorage.getItem('hide-preview')) {
+      hidePreviewBar();
+    }
+  })
+
+  function onButtonClick(event) {
+    var element = event.target;
+
+    if (element.className.indexOf('shopify-preview-bar__minimize') === -1) { return; }
+
+    window.sessionStorage.setItem('hide-preview', 'true');
+    hidePreviewBar();
+    document.removeEventListener('click', onButtonClick);
+  }
+
+  function hidePreviewBar() {
+    addCSS('.shopify-preview-bar { display:none; }');
+  }
+
+  function addCSS(css){
+    var head = document.getElementsByTagName('head')[0];
+    var style = document.createElement('style');
+
+    style.setAttribute('type', 'text/css');
+
+    if (style.styleSheet) {   // IE
+      style.styleSheet.cssText = css;
+    } else {                // Everything else
+      style.appendChild(document.createTextNode(css));
+    }
+
+    head.appendChild(style);
+  }
+
+  function isLocalStorageSupported () {
+    var mod = 'modernizr';
+    try {
+      localStorage.setItem(mod, mod);
+      localStorage.removeItem(mod);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+})();
+/* eslint-enable */


### PR DESCRIPTION
To 🎩 :
1. Switch to this branch on your computer
2. Change the reference of Slate Tools reference in a Slate theme `package.json` so that it points to your local Slate Tools repo, e.g. `"@shopify/slate-tools": "file:../slate-tools"`
3. Remove your theme's `node_modules` and reinstall: `rm -rf node_modules && npm install`
4. Run `slate watch` and test the minimize button. 

### What are you trying to accomplish with this PR?
Fixes https://github.com/Shopify/slate/issues/141

### Checklist
For maintainers:
- [x] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

